### PR TITLE
docs: Add GitHub Pages setup guide and update workflow configuration

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
       
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
@@ -39,7 +41,7 @@ jobs:
     # Only run on merged PRs or manual dispatch
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     environment:
-      name: github-pages
+      name: 'github-pages'
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build

--- a/GITHUB_PAGES_SETUP.md
+++ b/GITHUB_PAGES_SETUP.md
@@ -1,0 +1,67 @@
+# GitHub Pages 初期設定ガイド
+
+## エラーの原因
+
+以下のエラーが発生した場合：
+```
+Error: Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions
+Error: Not Found - https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site
+```
+
+これは、リポジトリでGitHub Pagesがまだ有効化されていないことが原因です。
+
+## 解決手順
+
+### 1. GitHub Pages を有効化
+
+1. GitHubリポジトリページに移動
+2. **Settings** タブをクリック
+3. 左サイドバーの **Pages** をクリック
+4. **Source** セクションで **GitHub Actions** を選択
+5. **Save** をクリック
+
+### 2. 初回デプロイ実行
+
+以下のいずれかの方法で初回デプロイを実行：
+
+#### 方法A: 手動実行
+1. リポジトリの **Actions** タブに移動
+2. **Deploy to GitHub Pages** ワークフローを選択
+3. **Run workflow** ボタンをクリック
+4. **Run workflow** を実行
+
+#### 方法B: PRマージ
+1. フィーチャーブランチで変更を作成
+2. mainブランチへのプルリクエストを作成
+3. プルリクエストをマージ（自動デプロイが実行される）
+
+### 3. 設定確認
+
+初回デプロイ成功後：
+- リポジトリの **Settings > Pages** で設定を確認
+- **Your site is published at** に表示されるURL（`https://shimasan0x00.github.io/jinja-pad/`）でアクセス確認
+
+## トラブルシューティング
+
+### Pages設定が見つからない場合
+- リポジトリがPublicであることを確認
+- GitHub Pro/Team/Enterpriseアカウントの場合はPrivateリポジトリでも利用可能
+
+### ワークフローが実行されない場合
+- mainブランチにワークフローファイルがコミットされていることを確認
+- **Actions** タブでワークフローが有効になっていることを確認
+
+### デプロイ後にサイトが表示されない場合
+- 数分待ってから再度アクセス（DNSの伝播に時間がかかる場合があります）
+- ブラウザのキャッシュをクリア
+
+## ワークフロー設定詳細
+
+現在の設定では：
+- **起動条件**: PRマージ時または手動実行時のみ
+- **デプロイ先**: `https://shimasan0x00.github.io/jinja-pad/`
+- **ソース**: GitHub Actions（自動ビルド・デプロイ）
+
+## 追加情報
+
+初回設定完了後は、`enablement: true` パラメータは不要になる可能性があります。正常にデプロイできるようになったら、この設定を削除できます。


### PR DESCRIPTION
- GitHub Pagesの初期設定ガイドを新規作成し、エラーの原因と解決手順を詳細に説明しました。
- GitHub Actionsの設定に`enablement: true`を追加し、デプロイ条件を明確化しました。